### PR TITLE
Minor tweaks to original definition of concurrency

### DIFF
--- a/community/023_concurrency.html
+++ b/community/023_concurrency.html
@@ -13,7 +13,7 @@
 <h2 id="con">2.3 Concurrency</h2>
 
 <p>Concurrency is a property of a system representing the fact that
-multiple activities are executed at the same time. According to Van
+multiple activities can be executed at the same time. According to Van
 Roy&nbsp;[<A
  HREF="0_bibliography.html#Roy2004">Roy04</A>], a program having "several independent activities, each of
 which executes at its own pace". 


### PR DESCRIPTION
Thank you for sharing this thesis, I have really enjoyed reading it!

Minor tweaks to original definition of concurrency, as it may be mis-leading to suggest that two or more activities _have_ to be executed at the same time, a system can be concurrent but not execute exactly at the same time, for instance time slicing on multi-tasking single core machine that's inferred to later in the thesis. See http://docs.oracle.com/cd/E19455-01/806-5257/6je9h032b/index.html and http://stackoverflow.com/a/1050257/192040
